### PR TITLE
Performance tweaks

### DIFF
--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -60,7 +60,14 @@ local commands = {
     "zrange",            "zrangebyscore",     "zrank",
     "zrem",              "zremrangebyrank",   "zremrangebyscore",
     "zrevrange",         "zrevrangebyscore",  "zrevrank",
-    "zscore",            "zunionstore",       "evalsha"
+    "zscore",            "zunionstore",       "evalsha",
+    -- Command list updated to Redis 2.6.16
+    "bitcount",          "bitop",             "client",
+    "dump",              "hincrbyfloat",      "incrbyfloat",
+    "migrate",           "pexpire",           "pexpireat",
+    "psetex",            "pubsub",            "pttl",
+    "restore",           "time"
+
 }
 
 


### PR DESCRIPTION
The table.insert command re-hash the table on every insert, using the # operator to find the last integer key of the table eliminates this overhead, and result in 1.5x to 17x performance boost across different benchmarks.

This:
    t[#t+1] = value
Is a lot faster than this (even in localized LuaJIT):
    table.insert(t, value)

Some published benchmark result:
http://blog.jgc.org/2013/04/performance-of-array-creation-in-lua.html

The only draw back is that the # operator doesn't actually count the numbers of items in the table (according to http://lua-users.org/wiki/TablesTutorial), which isn't needed anyway when items are being sequentially inserted.

We have been using the # operator in production for months without any issue, in fact we no longer have "local table.insert" in any of our codes.

We highly recommend you guys to replace all the table.insert across all lua codes with t[#t+1] = x and gain extra performances.

Thanks for the hard work agentzh, keep it up!
