### PR TITLE
Skipping responses

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -260,9 +260,7 @@ skip_responses
 
 Instructs the Redis client to skip incoming responses from the server. 
 
-When `true`, a `ngx.null` value is returned on every Redis operation.
-
-Use this property in specific high volume write scenarios where invoking the default `tcpsock:receive` function call on every operation is considered too expensive.
+Use this property in specific high volume write scenarios where reading the response on every operation is considered too expensive.
 
 get_reused_times
 ----------------

--- a/README.markdown
+++ b/README.markdown
@@ -15,6 +15,7 @@ Table of Contents
     * [connect](#connect)
     * [set_timeout](#set_timeout)
     * [set_keepalive](#set_keepalive)
+    * [skip_responses](#skip_responses)
     * [get_reused_times](#get_reused_times)
     * [close](#close)
     * [init_pipeline](#init_pipeline)
@@ -252,6 +253,16 @@ In case of success, returns `1`. In case of errors, returns `nil` with a string 
 Only call this method in the place you would have called the `close` method instead. Calling this method will immediately turn the current redis object into the `closed` state. Any subsequent operations other than `connect()` on the current objet will return the `closed` error.
 
 [Back to TOC](#table-of-contents)
+
+skip_responses
+------------
+`syntax: red:skip_responses(bool_skip)`
+
+Instructs the Redis client to skip incoming responses from the server. 
+
+When `true`, a `ngx.null` value is returned on every Redis operation.
+
+Use this property in specific high volume write scenarios where invoking the default `tcpsock:receive` function call on every operation is considered too expensive.
 
 get_reused_times
 ----------------

--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -10,7 +10,6 @@ local unpack = unpack
 local setmetatable = setmetatable
 local tonumber = tonumber
 local error = error
-local skip_responses = false
 
 local ok, new_tab = pcall(require, "table.new")
 if not ok then

--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -100,8 +100,8 @@ function _M.set_timeout(self, timeout)
     return sock:settimeout(timeout)
 end
 
-function _M.skip_responses(self, skip_responses)
-    _M._skip_responses = skip_responses
+function _M.skip_responses(self, bool_skip)
+    _M._skip_responses = bool_skip
 end
 
 function _M.connect(self, ...)

--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -10,7 +10,7 @@ local unpack = unpack
 local setmetatable = setmetatable
 local tonumber = tonumber
 local error = error
-
+local skip_responses = false
 
 local ok, new_tab = pcall(require, "table.new")
 if not ok then
@@ -100,6 +100,9 @@ function _M.set_timeout(self, timeout)
     return sock:settimeout(timeout)
 end
 
+function _M.skip_responses(self, skip)
+    skip_responses = skip
+end
 
 function _M.connect(self, ...)
     local sock = self.sock
@@ -142,6 +145,10 @@ end
 
 
 local function _read_reply(sock)
+    if skip_responses then
+        return null
+    end
+
     local line, err = sock:receive()
     if not line then
         return nil, err

--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -11,6 +11,7 @@ local setmetatable = setmetatable
 local tonumber = tonumber
 local error = error
 
+
 local ok, new_tab = pcall(require, "table.new")
 if not ok then
     new_tab = function (narr, nrec) return {} end
@@ -99,9 +100,11 @@ function _M.set_timeout(self, timeout)
     return sock:settimeout(timeout)
 end
 
+
 function _M.skip_responses(self, bool_skip)
     _M._skip_responses = bool_skip
 end
+
 
 function _M.connect(self, ...)
     local sock = self.sock

--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -100,8 +100,8 @@ function _M.set_timeout(self, timeout)
     return sock:settimeout(timeout)
 end
 
-function _M.skip_responses(self, skip)
-    skip_responses = skip
+function _M.skip_responses(self, skip_responses)
+    _M._skip_responses = skip_responses
 end
 
 function _M.connect(self, ...)
@@ -145,7 +145,7 @@ end
 
 
 local function _read_reply(sock)
-    if skip_responses then
+    if _M._skip_responses then
         return null
     end
 

--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -147,11 +147,7 @@ end
 
 
 local function _read_reply(sock)
-    if _M._skip_responses then
-        return null
-    end
-
-    local line, err = sock:receive()
+    local line, err = (_M._skip_responses and sock:receive(0) or sock:receive())
     if not line then
         return nil, err
     end


### PR DESCRIPTION
I've came across a very specific scenario where due to a high volume of write requests, calling `tcpsock:receive` after every operation was too expensive. In this scenario, counters on Redis were incremented and decremented in a _write-and-forget_ fashion.

For this reason I've introduced a new `skip_responses(bool_skip)` function to be able to optionally instruct the client to discard every response by skipping the `tcpsock:receive` function call.

I've submitted this pull request just in case somebody else needs it.
