### PR TITLE
use pkg-config instead of hardcoding paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 OPENRESTY_PREFIX=/usr/local/openresty-debug
 
-PREFIX ?=          /usr/local
-LUA_INCLUDE_DIR ?= $(PREFIX)/include
-LUA_LIB_DIR ?=     $(PREFIX)/lib/lua/$(LUA_VERSION)
+PREFIX ?=          $(shell pkg-config luajit --variable=prefix)
+LUA_INCLUDE_DIR ?= $(shell pkg-config luajit --cflags-only-I)
+LUA_LIB_DIR ?=     $(shell pkg-config luajit --variable=INSTALL_LMOD)
 INSTALL ?= install
 
 .PHONY: all test install
@@ -10,8 +10,8 @@ INSTALL ?= install
 all: ;
 
 install: all
-	$(INSTALL) -d $(DESTDIR)/$(LUA_LIB_DIR)/resty
-	$(INSTALL) lib/resty/*.lua $(DESTDIR)/$(LUA_LIB_DIR)/resty
+	$(INSTALL) -d $(DESTDIR)$(LUA_LIB_DIR)/resty
+	$(INSTALL) lib/resty/*.lua $(DESTDIR)$(LUA_LIB_DIR)/resty
 
 test: all
 	PATH=$(OPENRESTY_PREFIX)/nginx/sbin:$$PATH prove -I../test-nginx/lib -r t


### PR DESCRIPTION
Please accept this patch which uses pkg-config to figure out where to install things instead of the existing hardcoded ones.. I've assumed everyone is using luajit with nginx.
