### PR TITLE
doc: check redis return error more stick

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -118,7 +118,7 @@ Synopsis
 
                 for i, res in ipairs(results) do
                     if type(res) == "table" then
-                        if not res[1] then
+                        if res[1] == false then
                             ngx.say("failed to run command ", i, ": ", res[2])
                         else
                             -- process the table value


### PR DESCRIPTION
some command may return empty table like hkeys, smembers, and etc

It's better to be more stick, though there is no error for the example list in Synopsis