### PR TITLE
optimize: move string concatenation to the C land

### DIFF
--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -4,7 +4,6 @@
 local sub = string.sub
 local byte = string.byte
 local tcp = ngx.socket.tcp
-local concat = table.concat
 local null = ngx.null
 local type = type
 local pairs = pairs
@@ -268,8 +267,9 @@ local function _gen_req(args)
         end
     end
 
-    -- it is faster to do string concatenation on the Lua land
-    return concat(req)
+    -- it is much faster to do string concatenation on the C land
+    -- in some real world (large number of string in Lua)
+    return req
 end
 
 

--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -268,7 +268,7 @@ local function _gen_req(args)
     end
 
     -- it is much faster to do string concatenation on the C land
-    -- in some real world (large number of string in Lua)
+    -- in real world (large number of strings in the Lua VM)
     return req
 end
 


### PR DESCRIPTION
This patch make cpu from `90%` to `40%` in my recently project.
I got the below result when I run `lgcstat`
```
(gdb) lgcstat
301463 str        objects: max=2012, avg = 31, min=18, sum=9597298
586 upval      objects: max=24, avg = 24, min=24, sum=14064
320345 thread     objects: max=1120, avg = 664, min=424, sum=212712496
213 proto      objects: max=2579, avg = 356, min=74, sum=75945
160947 func       objects: max=144, avg = 20, min=20, sum=3231576
  91 trace      objects: max=1860, avg = 606, min=160, sum=55208
160032 cdata      objects: max=4112, avg = 16, min=12, sum=2564600
1213829 tab        objects: max=6291488, avg = 159, min=32, sum=194150416
272538 udata      objects: max=17694, avg = 440, min=32, sum=119927236

sizeof strhash 2097152
sizeof g->tmpbuf 2048
sizeof ctype_state 4568
sizeof jit_state 3472

total sz 544441311
g->strnum 301463, g->gc.total 544441311
elapsed: 284.000000 sec
```

There is not big performance difference when the number of string in Lua land is small.
But do string concatenation to the C land performance much better when the number is large.