### PR TITLE
add set_timeouts method

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -245,7 +245,7 @@ set_timeouts
 ----------
 `syntax: red:set_timeouts(connect_timeout, send_timeout, read_timeout)`
 
-Sets each timeouts (in ms) protection for subsequent operations more exactly.
+Sets each timeout (in ms) threshold with finer granularity than `set_timeout()` method.
 
 [Back to TOC](#table-of-contents)
 

--- a/README.markdown
+++ b/README.markdown
@@ -14,6 +14,7 @@ Table of Contents
     * [new](#new)
     * [connect](#connect)
     * [set_timeout](#set_timeout)
+    * [set_timeouts](#set_timeouts)
     * [set_keepalive](#set_keepalive)
     * [get_reused_times](#get_reused_times)
     * [close](#close)
@@ -237,6 +238,14 @@ set_timeout
 `syntax: red:set_timeout(time)`
 
 Sets the timeout (in ms) protection for subsequent operations, including the `connect` method.
+
+[Back to TOC](#table-of-contents)
+
+set_timeouts
+----------
+`syntax: red:set_timeouts(connect_timeout, send_timeout, read_timeout)`
+
+Sets each timeouts (in ms) protection for subsequent operations more exactly.
 
 [Back to TOC](#table-of-contents)
 

--- a/README.markdown
+++ b/README.markdown
@@ -234,7 +234,7 @@ An optional Lua table can be specified as the last argument to this method to sp
 [Back to TOC](#table-of-contents)
 
 set_timeout
-----------
+-----------
 `syntax: red:set_timeout(time)`
 
 Sets the timeout (in ms) protection for subsequent operations, including the `connect` method.
@@ -242,7 +242,7 @@ Sets the timeout (in ms) protection for subsequent operations, including the `co
 [Back to TOC](#table-of-contents)
 
 set_timeouts
-----------
+------------
 `syntax: red:set_timeouts(connect_timeout, send_timeout, read_timeout)`
 
 Sets each timeout (in ms) threshold with finer granularity than `set_timeout()` method.
@@ -250,7 +250,7 @@ Sets each timeout (in ms) threshold with finer granularity than `set_timeout()` 
 [Back to TOC](#table-of-contents)
 
 set_keepalive
-------------
+-------------
 `syntax: ok, err = red:set_keepalive(max_idle_timeout, pool_size)`
 
 Puts the current Redis connection immediately into the ngx_lua cosocket connection pool.

--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -22,7 +22,7 @@ if not ok or type(new_tab) ~= "function" then
 end
 
 
-local _M = new_tab(0, 54)
+local _M = new_tab(0, 55)
 
 _M._VERSION = '0.27'
 

--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -75,6 +75,7 @@ function _M.set_timeout(self, timeout)
     return sock:settimeout(timeout)
 end
 
+
 function _M.set_timeouts(self, connect_timeout, send_timeout, read_timeout)
     local sock = rawget(self, "_sock")
     if not sock then
@@ -84,6 +85,7 @@ function _M.set_timeouts(self, connect_timeout, send_timeout, read_timeout)
 
     return sock:settimeouts(connect_timeout, send_timeout, read_timeout)
 end
+
 
 function _M.connect(self, ...)
     local sock = rawget(self, "_sock")

--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -72,7 +72,8 @@ function _M.set_timeout(self, timeout)
         return
     end
 
-    return sock:settimeout(timeout)
+    sock:settimeout(timeout)
+    return
 end
 
 
@@ -83,7 +84,8 @@ function _M.set_timeouts(self, connect_timeout, send_timeout, read_timeout)
         return
     end
 
-    return sock:settimeouts(connect_timeout, send_timeout, read_timeout)
+    sock:settimeouts(connect_timeout, send_timeout, read_timeout)
+    return
 end
 
 

--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -75,6 +75,15 @@ function _M.set_timeout(self, timeout)
     return sock:settimeout(timeout)
 end
 
+function _M.set_timeouts(self, connect_timeout, send_timeout, read_timeout)
+    local sock = rawget(self, "_sock")
+    if not sock then
+        error("not initialized", 2)
+        return
+    end
+
+    return sock:settimeouts(connect_timeout, send_timeout, read_timeout)
+end
 
 function _M.connect(self, ...)
     local sock = rawget(self, "_sock")

--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -73,7 +73,6 @@ function _M.set_timeout(self, timeout)
     end
 
     sock:settimeout(timeout)
-    return
 end
 
 
@@ -85,7 +84,6 @@ function _M.set_timeouts(self, connect_timeout, send_timeout, read_timeout)
     end
 
     sock:settimeouts(connect_timeout, send_timeout, read_timeout)
-    return
 end
 
 

--- a/t/count.t
+++ b/t/count.t
@@ -40,6 +40,6 @@ __DATA__
 --- request
 GET /t
 --- response_body
-size: 54
+size: 55
 --- no_error_log
 [error]


### PR DESCRIPTION
It's a copy-paste from https://github.com/ledgetech/lua-resty-http/blob/master/lib/resty/http.lua
To provide a set_timeouts method
Then You can set connect_timeout, send_timeout, read_timeout seperately