### PR TITLE
Add workaround for dot-separated commands of Redis modules

### DIFF
--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -237,6 +237,16 @@ end
 local function _do_cmd(self, ...)
     local args = {...}
 
+    ---@authov Victor Burre <victor.burre@gmail.com>
+    -- It is a workaround for invocking dot-separated commands
+    -- of Redis modules like RedisJSON, rediSQL, etc. In order to
+    -- properly call such command, just substitute 'dot' with 'underscore'.
+    -- Example:
+    --   redis:json_set("key", ".", "{}"
+    --   redis:json_get("key")
+    -- Below we just swap they backward.
+    args[1] = args[1]:gsub("_", ".")
+
     local sock = rawget(self, "_sock")
     if not sock then
         return nil, "not initialized"


### PR DESCRIPTION
Hi there!

I ran into a problem when I tried to work with the RedisJSON module, because its commands consist of a prefix and the command itself, separated by a dot. Having looked at other similar modules, I found that they also use a similar approach. 

But the `resty/redis` client implementation, based on the `__index` "magic" method, cannot handle such commands. Calling the method (function) through `[]` also did not bring results. So I did a little trick.

I propose to use the "underscore" (`_`) instead of the "dot" (`.`) when calling the method, and swap them back in the client code. For example:
```lua
local client = redis:new()

local ok, err = client:connect(host, port)
-- error checking goes here

client:json_set("key", "root", '{"key" : "value"}')
```

Perhaps this is too simple solution, but it works for me and, I hope, for someone else.
