### PR TITLE
support commands that have a '.' (via '__')

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -187,6 +187,11 @@ Here are some more examples:
     local res, err = red:hmset("myhash", "field1", "Hello", "field2", "World")
 ```
 
+```lua
+    -- RedisBloom commands contain a dot (use '__' instead)
+    local res, err = red:cf__exists("key", "item")
+```
+
 All these command methods returns a single result in success and `nil` otherwise. In case of errors or failures, it will also return a second value which is a string describing the error.
 
 A Redis "status reply" results in a string typed return value with the "+" prefix stripped.

--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -663,7 +663,7 @@ end
 setmetatable(_M, {__index = function(self, cmd)
     local method =
         function (self, ...)
-            return _do_cmd(self, cmd, ...)
+            return _do_cmd(self, cmd:gsub("__", "."), ...)
         end
 
     -- cache the lazily generated method in our


### PR DESCRIPTION
The commands made available by [RedisBloom](https://oss.redislabs.com/redisbloom/) have a `.`, so lets make them accessible via `__` substitution.