### PR TITLE
bugfix: connect to unix socket without opts table

### DIFF
--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -140,9 +140,13 @@ function _M.connect(self, host, port_or_opts, opts)
     local ok, err
 
     if unix then
-        ok, err = sock:connect(host, port_or_opts)
-        opts = port_or_opts
-
+         -- second argument of sock:connect() cannot be nil
+         if port_or_opts ~= nil then
+             ok, err = sock:connect(host, port_or_opts)
+             opts = port_or_opts
+         else
+             ok, err = sock:connect(host)
+         end
     else
         ok, err = sock:connect(host, port_or_opts, opts)
     end

--- a/t/ssl.t
+++ b/t/ssl.t
@@ -244,3 +244,49 @@ failed to connect: failed to do ssl handshake: 18: self signed certificate
     }
 --- response_body
 ok
+
+
+
+=== TEST 6: non-ssl connection to unix socket (issue #187)
+--- config
+    location /t {
+        content_by_lua_block {
+            local redis = require "resty.redis"
+            local red = redis:new()
+
+            red:set_timeout(100)
+
+            local ok, err = red:connect("unix:$TEST_NGINX_HTML_DIR/nginx-ssl.sock")
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+
+
+
+=== TEST 7: non-ssl connection to unix socket with second argument nil (issue #187)
+--- config
+    location /t {
+        content_by_lua_block {
+            local redis = require "resty.redis"
+            local red = redis:new()
+
+            red:set_timeout(100)
+
+            local ok, err = red:connect("unix:$TEST_NGINX_HTML_DIR/nginx-ssl.sock",nil)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok


### PR DESCRIPTION
The second argument of `sock:connect()` cannot be `nil`.
Fixes #187
Bug introduced by 79d24214095c921b879319e512b2f20fddf0795e