### PR TITLE
#187 redis.lua:143: bad argument #2 to 'connect' (number expected, got nil)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -77,7 +77,7 @@ Synopsis
 
                 -- or connect to a unix domain socket file listened
                 -- by a redis server:
-                --     local ok, err = red:connect("unix:/path/to/redis.sock")
+                --     local ok, err = red:connect("unix:///path/to/redis.sock")
 
                 local ok, err = red:connect("127.0.0.1", 6379)
                 if not ok then

--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -140,9 +140,12 @@ function _M.connect(self, host, port_or_opts, opts)
     local ok, err
 
     if unix then
-        ok, err = sock:connect(host, port_or_opts)
-        opts = port_or_opts
-
+        if port_or_opts ~= nil then
+            ok, err = sock:connect(host, port_or_opts)
+            opts = port_or_opts
+        else
+            ok, err = sock:connect(host)
+        end
     else
         ok, err = sock:connect(host, port_or_opts, opts)
     end


### PR DESCRIPTION
```
lua entry thread aborted: runtime error: /usr/local/openresty/lualib/resty/redis.lua:143: bad argument #2 to 'connect' (number expected, got nil)
stack traceback:
coroutine 0:
	[C]: in function 'connect'
	/usr/local/openresty/lualib/resty/redis.lua:143: in function 'connect'
```

Solution of the above error.

Error correction in the example in the readme file.
