### PR TITLE
bugfix: lack close() when receive timeout

### DIFF
--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -230,6 +230,9 @@ local function _read_reply(self, sock)
 
         local dummy, err = sock:receive(2) -- ignore CRLF
         if not dummy then
+            if err == "timeout" then
+                sock:close()
+            end
             return nil, err
         end
 


### PR DESCRIPTION
Sock need close when sock:receive(2) timeout at _read_reply().
Fixes [#207](https://github.com/openresty/lua-resty-redis/issues/207)