### PR TITLE
fix: check for socket reuse

### DIFF
--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -162,7 +162,7 @@ function _M.connect(self, host, port_or_opts, opts)
         return ok, err
     end
 
-    if opts and opts.ssl then
+    if opts and opts.ssl and sock:getreusedtimes() == 0 then
         ok, err = sock:sslhandshake(false, opts.server_name, opts.ssl_verify)
         if not ok then
             return ok, "failed to do ssl handshake: " .. err


### PR DESCRIPTION
Determine if the current connection comes from the pool. If yes, reuse the SSL session from the previous connection. Otherwise, proceed with the SSL handshake.