### PR TITLE
test: check "error" in the logs when using set_timeouts

### DIFF
--- a/t/sanity.t
+++ b/t/sanity.t
@@ -803,8 +803,8 @@ failed to connect: connection refused
         }
 --- response_body
 failed to connect: timeout
---- no_error_log
-[error]
+--- error_log
+lua tcp socket connect timed out
 
 
 
@@ -841,8 +841,8 @@ failed to connect: timeout
 --- response_body
 flushall: OK
 failed to blpop: timeout
---- no_error_log
-[error]
+--- error_log
+lua tcp socket send timed out
 
 
 
@@ -879,8 +879,8 @@ failed to blpop: timeout
 --- response_body
 flushall: OK
 failed to blpop: timeout
---- no_error_log
-[error]
+--- error_log
+lua tcp socket read timed out
 
 
 

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -804,7 +804,7 @@ failed to connect: connection refused
 --- response_body
 failed to connect: timeout
 --- no_error_log
-[alert]
+[error]
 
 
 
@@ -842,7 +842,7 @@ failed to connect: timeout
 flushall: OK
 failed to blpop: timeout
 --- no_error_log
-[alert]
+[error]
 
 
 
@@ -880,7 +880,7 @@ failed to blpop: timeout
 flushall: OK
 failed to blpop: timeout
 --- no_error_log
-[alert]
+[error]
 
 
 

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -842,7 +842,7 @@ lua tcp socket connect timed out
 flushall: OK
 failed to blpop: timeout
 --- error_log
-lua tcp socket send timed out
+lua tcp socket read timed out
 
 
 


### PR DESCRIPTION
This PR is just to test a hunch in your CI with regards to `set_timeouts`, as tests elsewhere seem to show it failing. For example:

```
pattern "[error]" should not match any line in error.log but matches line "2021/06/17 17:35:51 [error] 28935#0: *1 attempt to send data on a closed socket: u:0000000000000000, c:0000000000000000, ft:0 eof:0, client: 127.0.0.1, server: localhost, request: \"GET /t HTTP/1.1\", host: \"localhost\"" (req 0)
# 2021/06/17 17:35:51 [debug] 28935#0: *1 malloc: 000055984F6FC320:10
# 2021/06/17 17:35:51 [debug] 28935#0: *1 malloc: 000055984F6FC270:16
# 2021/06/17 17:35:51 [debug] 28935#0: *1 malloc: 000055984F6F4980:32
# 2021/06/17 17:35:51 [debug] 28935#0: *1 malloc: 000055984F6FAAB0:16
# 2021/06/17 17:35:51 [debug] 28935#0: *1 malloc: 000055984F6FA2A0:16
# 2021/06/17 17:35:51 [debug] 28935#0: *1 malloc: 000055984F6FE0E0:16
# 2021/06/17 17:35:51 [debug] 28935#0: *1 malloc: 000055984F6FEDE0:21
# 2021/06/17 17:35:51 [debug] 28935#0: *1 malloc: 000055984F6FED90:16
# 2021/06/17 17:35:51 [debug] 28935#0: *1 lua tcp socket connect timeout: 60000
```

Using `set_timeout` individually works fine.
