### PR TITLE
optimize: return setmetatable is NYI which can not be jit compiled.

### DIFF
--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -87,13 +87,14 @@ function _M.new(self)
     if not sock then
         return nil, err
     end
-    return setmetatable({ _sock = sock,
+    local redis = setmetatable({ _sock = sock,
                           _subscribed = false,
                           _n_channel = {
                             unsubscribe = 0,
                             punsubscribe = 0,
                           },
                         }, mt)
+    return redis
 end
 
 


### PR DESCRIPTION
Previously with `grep NYI`:

```
[TRACE --- (26/stitch) redis.lua:86 -- NYI: return to lower frame at connector.lua:362]
[TRACE --- (33/stitch) redis.lua:189 -- NYI: bytecode UCLO   at connector.lua:407]
```

After patch:

```
[TRACE --- (23/stitch) redis.lua:190 -- NYI: bytecode UCLO   at connector.lua:407]
```