### PR TITLE
bugfix: connection is closed after the blpop and brpop calls time out

### DIFF
--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -49,7 +49,7 @@ local common_cmds = {
 
 
 local sub_commands = {
-    "subscribe", "psubscribe"
+    "subscribe", "psubscribe", "blpop", "brpop"
 }
 
 


### PR DESCRIPTION
These two functions are blocking calls and are processed in subscribe mode